### PR TITLE
Add duration check and clip trimming fix

### DIFF
--- a/shuffle-montage.sh
+++ b/shuffle-montage.sh
@@ -29,9 +29,9 @@ for cmd in ffmpeg ffprobe awk realpath; do
   command -v $cmd >/dev/null || { echo "'$cmd' not found"; exit 1; }
 done
 
-TARGET_SEC=120
-MIN_CLIP=4
-MAX_CLIP=12
+: "${TARGET_SEC:=120}"
+: "${MIN_CLIP:=4}"
+: "${MAX_CLIP:=12}"
 
 typeset -a durations prefix
 file_count=${#FILES[@]}
@@ -73,7 +73,7 @@ done
 
 TMPDIR=$(mktemp -d)
 CLIP_LIST="$TMPDIR/clip_list.txt"
-> "$CLIP_LIST"
+: > "$CLIP_LIST"
 
 PART_DUR=$(awk 'BEGIN{printf "%f", '"$total_sec"'/'"$N"'}')
 echo "Each partition ≈ ${PART_DUR}s" >&2
@@ -97,7 +97,7 @@ for (( i=1; i<=N; i++ )); do
   out_clip="$TMPDIR/clip${i}.mkv"
   echo "Clip $i: file='${file##*/}', start=${local_start}s, len=${L}s" >&2
 
-  ffmpeg -hide_banner -loglevel error -y -ss "$local_start" -i "$file" -t "$L" -c copy -avoid_negative_ts make_zero "$out_clip"
+  ffmpeg -hide_banner -loglevel error -y -ss "$local_start" -copyts -i "$file" -t "$L" -c copy -avoid_negative_ts make_zero "$out_clip"
 
   printf "file '%s'\n" "$out_clip" >>"$CLIP_LIST"
 done

--- a/tests/bin/osascript
+++ b/tests/bin/osascript
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Stub osascript for tests
+# Log arguments if OSASCRIPT_LOG is set
+if [ -n "$OSASCRIPT_LOG" ]; then
+  echo "osascript $*" >> "$OSASCRIPT_LOG"
+fi
+exit 0

--- a/tests/montage_success.bats
+++ b/tests/montage_success.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+load "./test_helper.bash"
+
+@test "montage is created from many videos" {
+  run zsh ./shuffle-montage.sh "$VIDEO_DIR"/test*.mp4
+  assert_success
+  montage_file=$(ls "$HOME/Desktop"/montage_*.mkv)
+  [ -f "$montage_file" ]
+  log_file=$(ls "$HOME/Desktop"/Montage-Shuffle-*.log)
+  [ -f "$log_file" ]
+  cat "$log_file"
+
+  planned=$(grep -E "^Planning" "$log_file" | awk '{print $2}')
+  expected=$(( (2*TARGET_SEC) / (MIN_CLIP + MAX_CLIP) ))
+  (( planned == expected ))
+
+  total_clips=$(grep -c '^Clip ' "$log_file")
+  (( total_clips == planned ))
+
+  total_len=$(awk -F"len=" '/Clip/{split($2,a,"s");sum+=a[1]}END{print sum}' "$log_file")
+  (( total_len == TARGET_SEC ))
+
+  duration=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$montage_file")
+  dur=${duration%.*}
+  (( dur == TARGET_SEC ))
+
+}

--- a/tests/no_input.bats
+++ b/tests/no_input.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+load "./test_helper.bash"
+
+@test "script fails with no input" {
+  run zsh ./shuffle-montage.sh
+  assert_failure
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,25 @@
+load '/usr/lib/bats/bats-support/load'
+load '/usr/lib/bats/bats-assert/load'
+
+setup() {
+  TEST_ROOT=$(mktemp -d)
+  export HOME="$TEST_ROOT/home"
+  mkdir -p "$HOME/Desktop"
+  export PATH="$(pwd)/tests/bin:$PATH"
+  export OSASCRIPT_LOG="$TEST_ROOT/osascript.log"
+  export TARGET_SEC=120
+  export MIN_CLIP=5
+  export MAX_CLIP=15
+  VIDEO_DIR="$TEST_ROOT/videos"
+  mkdir -p "$VIDEO_DIR"
+  for i in $(seq 1 24); do
+    dur=$(( 60 + (i * 7 % 61) ))
+    ffmpeg -y -f lavfi -i "testsrc=duration=${dur}:size=64x64:rate=1" \
+      -c:v libx264 -pix_fmt yuv420p -preset ultrafast -crf 28 \
+      "$VIDEO_DIR/test${i}.mp4" >/dev/null 2>&1
+  done
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}


### PR DESCRIPTION
## Summary
- fix ffmpeg invocation to preserve timestamps during clip extraction
- verify montage duration with ffprobe in tests

## Testing
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_684f3b530c40832b835796e1b954c0a8