### PR TITLE
Add exact length test

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Run the script with the video files you want to sample from:
 
 The resulting montage is written to your Desktop as `montage_<timestamp>.mkv`. A log file named `Montage-Shuffle-<timestamp>.log` is also placed on the Desktop.
 
+### Environment Variables
+
+Several optional environment variables control clip planning:
+
+- `TARGET_SEC` — desired total duration in seconds (default `120`)
+- `MIN_CLIP` / `MAX_CLIP` — bounds for individual clip length
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/tests/exact_length.bats
+++ b/tests/exact_length.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+load "./test_helper.bash"
+
+@test "montage duration equals TARGET_SEC" {
+  run zsh ./shuffle-montage.sh "$VIDEO_DIR"/test*.mp4
+  assert_success
+  montage_file=$(ls "$HOME/Desktop"/montage_*.mkv)
+  [ -f "$montage_file" ]
+  log_file=$(ls "$HOME/Desktop"/Montage-Shuffle-*.log)
+  [ -f "$log_file" ]
+
+  duration=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$montage_file")
+  dur=${duration%.*}
+  (( dur == TARGET_SEC ))
+
+  total_len=$(awk -F"len=" '/Clip/{split($2,a,"s");sum+=a[1]}END{print sum}' "$log_file")
+  (( total_len == dur ))
+}


### PR DESCRIPTION
## Summary
- add a bats test verifying video duration exactly matches `TARGET_SEC` when `EXACT_LENGTH=1`

## Testing
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_684f94930d5c832bb5818f040fab75d9