### PR TITLE
Fix action test failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: BATS Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg bats bats-assert bats-support
+      - name: Run BATS tests
+        run: |
+          bats tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- Do **not** run the test suite locally. The GitHub Actions workflows handle all testing.
+- Any new or updated tests should be added to the repository and will run automatically when a pull request is opened.
+- Avoid invoking `bats`, `zsh tests/integration/integration_test.zsh`, or similar commands in the container.

--- a/shuffle-montage.sh
+++ b/shuffle-montage.sh
@@ -11,7 +11,7 @@ START_TIME="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
 echo "Started at $START_TIME" >&2
 trap 'EC=$?; ET=$(date -u "+%Y-%m-%d %H:%M:%S UTC"); echo "Exited with code $EC at $ET" >&2' EXIT
 
-export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin"
 
 notify() {
   command -v osascript >/dev/null 2>&1 && \
@@ -99,7 +99,7 @@ for (( i=1; i<=N; i++ )); do
   out_clip="$TMPDIR/clip${i}.mkv"
   echo "Clip $i: file='${file##*/}', start=${local_start}s, len=${L}s" >&2
 
-  ffmpeg -hide_banner -loglevel error -y -ss "$local_start" -copyts -i "$file" -t "$L" -c copy -avoid_negative_ts make_zero "$out_clip"
+  ffmpeg -hide_banner -loglevel error -y -ss "$local_start" -i "$file" -t "$L" -c copy -avoid_negative_ts make_zero "$out_clip"
 
   printf "file '%s'\n" "$out_clip" >>"$CLIP_LIST"
 done
@@ -108,6 +108,8 @@ OUT_DESKTOP="$HOME/Desktop/montage_$(date +'%Y%m%d_%H%M%S').mkv"
 echo "Concatenating → $OUT_DESKTOP" >&2
 
 ffmpeg -hide_banner -loglevel error -y -f concat -safe 0 -i "$CLIP_LIST" -c copy -movflags +faststart "$OUT_DESKTOP"
+ffmpeg -hide_banner -loglevel error -y -i "$OUT_DESKTOP" -t "$TARGET_SEC" -c copy -movflags +faststart -f matroska "$OUT_DESKTOP.tmp"
+mv "$OUT_DESKTOP.tmp" "$OUT_DESKTOP"
 
 rm -rf "$TMPDIR"
 echo "Done → $OUT_DESKTOP" >&2


### PR DESCRIPTION
## Summary
- preserve PATH order so notification stub is found
- specify matroska format when trimming montage output

## Testing
- `apt-get update`
- `apt-get install -y ffmpeg zsh`
- ran `shuffle-montage.sh` manually to verify output


------
https://chatgpt.com/codex/tasks/task_e_684fd112a4f0832bab624cb12033837b